### PR TITLE
Disgustingly high timeout on scans until code refactor

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var buildVersion = "0.1.28"
+var buildVersion = "0.1.29"
 
 var (
 	listenPort           = flag.String("listenPort", ":9634", "listen address for prometheus")

--- a/stats.go
+++ b/stats.go
@@ -64,10 +64,10 @@ func aeroInit() error {
 	scanpol.IncludeBinData = false
 	scanpol.FailOnClusterChange = *failOnClusterChange
 	scanpol.RecordQueueSize = *recordQueueSize
-	// scanpol.TotalTimeout = 2 * time.Minute
-	// scanpol.SocketTimeout = 2 * time.Minute
-	// policy.TotalTimeout = 2 * time.Minute
-	// policy.SocketTimeout = 2 * time.Minute
+	scanpol.TotalTimeout = 20 * time.Minute
+	scanpol.SocketTimeout = 20 * time.Minute
+	policy.TotalTimeout = 20 * time.Minute
+	policy.SocketTimeout = 20 * time.Minute
 	return nil
 }
 


### PR DESCRIPTION
Scan prio and sleeping after exception still doesnt prevent scans from stacking up. So adding a disgusting high timeout should help for now. This will be refactored.