### PR TITLE
Bugfix null set scan percent calc

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var buildVersion = "1.0.1"
+var buildVersion = "1.0.2"
 var expirationTTLCounts *prometheus.GaugeVec
 var expirationTTLPercents *prometheus.GaugeVec
 


### PR DESCRIPTION
    * Fixed a bug where nullset would come back as 0 record count, causing it to scan 100% of the data.
    * Clean up some casts.
    * Fix bug where maxRecCount would still be calculated if scanPercent>100
    * Clarify comments
    * Use <100 and >=100 instead of <99/>99
    * DRY
    * Get rid of countSetObjects in favor of countSet which will handle nullset and set specified