### PR TITLE
Typonamespace key not found bug

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var buildVersion = "4.0.2"
+var buildVersion = "4.0.3"
 var configFile = flag.String("configFile", "/etc/ttl-aerospike-exporter.yaml", "The yaml config file for the exporter")
 var ns_set_to_histograms = make(map[string]map[string]*prometheus.HistogramVec)
 var ns_set_to_ttl_unit = make(map[string]map[string]int)

--- a/collector.go
+++ b/collector.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var buildVersion = "4.0.3"
+var buildVersion = "4.0.4"
 var configFile = flag.String("configFile", "/etc/ttl-aerospike-exporter.yaml", "The yaml config file for the exporter")
 var ns_set_to_histograms = make(map[string]map[string]*prometheus.HistogramVec)
 var ns_set_to_ttl_unit = make(map[string]map[string]int)

--- a/conf.yaml
+++ b/conf.yaml
@@ -46,7 +46,7 @@ monitor:
     #  If you have a ~128,000 byte size record and resolution is set to 0.001 we will call observe 128,000 times.
     # this does mean we lose some resolution on how large the records are, because they'll be rounded down by 'n' bytes.
     # value is in KiB, recommend starting at something like 0.334 so our resolution will be around 334 bytes and we will call observe 334x less.
-    # This also artificially deflates the number, so you will have to scale it up. If we are observing 334x less data, you will need to 334x the final value from the histogram.
+    # This also artificially deflates the number, so you will have to scale it up. If we are observing 334x less data, you will need to 334x the final value from the histograms - though they should be accurate as a distribution.
     #  There is no good way around this.
     kbyteHistogramResolution: 0.334
     kbyteHistogram: 

--- a/conf.yaml
+++ b/conf.yaml
@@ -41,11 +41,13 @@ monitor:
     policySocketTimeout: 20m  # https://golang.org/pkg/time/#ParseDuration
     RecordsPerSecond: 100 # Utilizes the scan policy to limit RPS.
     ## KiB exports
-    # note on 'resolution here: this can have drastic perf implications
+    # WARNING: Resolution will have drastic perf implications
     #  This directly affects how many times we call histogram.Observe.
-    #  ex. If you have a ~128,000 byte size record and resolution is set to 0.001 we will call observe 128,000 times.
+    #  If you have a ~128,000 byte size record and resolution is set to 0.001 we will call observe 128,000 times.
     # this does mean we lose some resolution on how large the records are, because they'll be rounded down by 'n' bytes.
-    # value is in KiB, recommend starting at something like 0.334 so our resolution will be around 334 bytes
+    # value is in KiB, recommend starting at something like 0.334 so our resolution will be around 334 bytes and we will call observe 334x less.
+    # This also artificially deflates the number, so you will have to scale it up. If we are observing 334x less data, you will need to 334x the final value from the histogram.
+    #  There is no good way around this.
     kbyteHistogramResolution: 0.334
     kbyteHistogram: 
       deviceSize: true

--- a/stats.go
+++ b/stats.go
@@ -297,8 +297,16 @@ func measureRecordSize(client *as.Client, key *as.Key, operations []*as.Operatio
 		logrus.Error("Could not convert 'devize' to int")
 	}
 
+	devsize_kb := float64(devsize) / 1024.0
+	memsize_kb := float64(memsize) / 1024.0
+
+	// if config.Service.Verbose {
+	// 	logrus.Debug("Found devsize: ", devsize, " converted to KiB -> ", devsize_kb)
+	// 	logrus.Debug("Found memsize: ", memsize, " converted to KiB -> ", memsize_kb)
+	// }
+
 	// return it as KiB
-	return float64(devsize / 1024), float64(memsize / 1024), err
+	return devsize_kb, memsize_kb, err
 }
 
 // simple function to take a human duration input like 1m20s and return a time.Duration output


### PR DESCRIPTION
- don't crash if the namespace was typod and somehow we fetched rf=0, give a good error message instead
- don't crash with key-not-found. thats expected as objects are expired/evicted
- for KiB resolution we need to convert stuff to floats earlier on to avoid dropping resolution