### PR TITLE
Rsm nosql 4138 allow size without ttl

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -409,7 +409,17 @@ func (r *ttlRange) publish(namespace, set string) {
 // toward the exported total). Non-expirable records are skipped.
 func processRecord(rec *as.Result, element monconf, hs *histSet, ttls *ttlRange) bool {
 	if rec.Record.Expiration == NON_EXPIRABLE_TTL_VALUE {
-		// non-expirable record; the Aerospike server already has a log ticket for this.
+		// size histograms are still recorded for non-expirable records; kbyte is skipped
+		// since it requires a meaningful TTL value as the observed dimension.
+		if element.SizeHistogramEnabled && hs.sizes != nil {
+			recordsize, err := measureRecordSize(client.Load(), rec.Record.Key, measureOps, opPolicy)
+			if err != nil && err != as.ErrKeyNotFound {
+				logrus.Errorf("Failure fetching record size. Err: %v", err)
+			}
+			if recordsize != 0 {
+				hs.sizes.WithLabelValues("recordsize").Observe(float64(recordsize))
+			}
+		}
 		return false
 	}
 	ttls.observe(rec.Record.Expiration)


### PR DESCRIPTION
Allow records without TTLs to still be counted in size histograms (we should be able to get their size from the primary index, even if they don't have a TTL, to my understanding).