### PR TITLE
feat: replace O(N) kib_hist Observe loop with O(1) size-weighted cust…

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -17,8 +17,8 @@ deploy hostname:
     if [[ -n "${AS_USER:-}" || -n "${AS_PASS:-}" ]]; then
         deploy_config="/tmp/.deploy-conf-$$.yaml"
         cp {{config}} "$deploy_config"
-        [[ -n "${AS_USER:-}" ]] && sed -i'' -e "s/^ *username:.*/  username: $AS_USER/" "$deploy_config"
-        [[ -n "${AS_PASS:-}" ]] && sed -i'' -e "s/^ *password:.*/  password: $AS_PASS/" "$deploy_config"
+        [[ -n "${AS_USER:-}" ]] && sed -i'' -e "s|^ *username:.*|  username: $AS_USER|" "$deploy_config"
+        [[ -n "${AS_PASS:-}" ]] && sed -i'' -e "s|^ *password:.*|  password: $AS_PASS|" "$deploy_config"
         trap 'rm -f "$deploy_config"' EXIT
     fi
     echo "==> Deploying to {{ssh_user}}@{{hostname}}:{{remote_dir}}/"
@@ -39,8 +39,8 @@ run-remote remotenode:
     run_config="/tmp/testconf-local.yaml"
     sed 's/aerospikeAddr:.*/aerospikeAddr: {{remotenode}}/' {{config}} > "$run_config"
     if [[ -n "${AS_USER:-}" || -n "${AS_PASS:-}" ]]; then
-        [[ -n "${AS_USER:-}" ]] && sed -i'' -e "s/^ *username:.*/  username: $AS_USER/" "$run_config"
-        [[ -n "${AS_PASS:-}" ]] && sed -i'' -e "s/^ *password:.*/  password: $AS_PASS/" "$run_config"
+        [[ -n "${AS_USER:-}" ]] && sed -i'' -e "s|^ *username:.*|  username: $AS_USER|" "$run_config"
+        [[ -n "${AS_PASS:-}" ]] && sed -i'' -e "s|^ *password:.*|  password: $AS_PASS|" "$run_config"
     fi
     echo "==> Running against {{remotenode}} (config: $run_config)"
     go run . -configFile "$run_config"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A custom exporter that samples records on each server on a schedule and exports 
 
 ## Example queries
 
-### How large are the users in the fresh TTL range?
+### How large are the records in the fresh TTL range?
 ```promql
 # Scenario: default-ttl=33d
 histogram_quantile(0.50, sum(rate(aerospike_ttl_kib_hist_bucket{namespace="myns"}[$__rate_interval])) by (le))
@@ -80,7 +80,7 @@ All metrics are in the `aerospike_ttl_` namespace.
 | Metric | Labels | Description |
 |--------|--------|-------------|
 | `counts_hist` | `namespace`, `set`, `ttlUnit` | Records per TTL bucket. |
-| `kib_hist` | `namespace`, `set`, `ttlUnit`, `storage_type` | Bytes per TTL bucket (`storage_type=recordsize`). Requires `kbyteHistogramEnabled: true`. |
+| `kib_hist` | `namespace`, `set`, `ttlUnit`, `storage_type` | KiB per TTL bucket, size-weighted (`storage_type=recordsize`). Requires `kbyteHistogramEnabled: true`. |
 | `size_bytes_hist` | `namespace`, `set`, `metadata_op` | Record size distribution in raw bytes (`metadata_op=recordsize`). Requires `sizeHistogramEnabled: true`. Uses `sizeBuckets` config. |
 
 ### Per-set gauges
@@ -262,8 +262,7 @@ Each entry targets one namespace/set. In auto-discovery mode they act as per-set
 | `policyTotalTimeout` | string | Policy total timeout (for metadata reads). |
 | `policySocketTimeout` | string | Policy socket timeout. |
 | `recordsPerSecond` | int | Server-side RPS throttle. `0` = unlimited. |
-| `kbyteHistogramEnabled` | bool | Enable `kib_hist` (bytes-per-TTL-bucket). |
-| `kbyteHistogramResolution` | float | KiB step for the byte histogram observe loop. Lower = higher resolution but more CPU. Recommend `0.334` (334-byte resolution). Max resolution `0.001`. |
+| `kbyteHistogramEnabled` | bool | Enable `kib_hist` (size-weighted TTL histogram). Bucket counts represent total KiB per TTL bucket, O(1) per record. |
 | `sizeHistogramEnabled` | bool | Enable `size_bytes_hist` (record-size distribution). |
 | `ttlBuckets` | bucketConfig | TTL histogram bucket config (see Bucket configuration). |
 | `sizeBuckets` | bucketConfig | Size histogram bucket config (see Bucket configuration). |
@@ -283,7 +282,11 @@ level=info msg="Scan complete." namespace=myns set=myset total(records exported)
 
 The exporter only **scans** Aerospike — it never writes. Record size is read with a metadata-only `Operate` that carries `TTLDontUpdate`, so even the touched record's TTL/generation is left alone.
 
-`scripts/gen-stability-test.sh` is the end-to-end proof. It is **hermetic**: spins up an ephemeral community-edition Aerospike in Docker (no host, no creds), seeds a canary record, pins its `gen`, runs the real exporter binary for a bounded scan window, then re-reads `gen`. Unchanged `gen` = read-only (PASS); changed `gen` = exporter wrote (FAIL). The test also fails if the exporter dies before scanning, so an unchanged `gen` can never be a false pass.
+`scripts/gen-stability-test.sh` is the end-to-end proof. It is **hermetic**: spins up an ephemeral enterprise-edition Aerospike in Docker (single-node, no license needed), seeds 10 canary records with a positive TTL, runs the real exporter binary with all histogram types enabled (`counts_hist`, `kib_hist`, `size_bytes_hist`), then:
+
+1. Scrapes `/metrics` and asserts every histogram has `>= 10` observations — the exporter must actually produce histograms for the gen check to be meaningful.
+2. Re-reads `gen` for all 10 canaries. Any change = exporter wrote (FAIL).
+3. Runs a negative control: deliberately writes a canary and confirms the gen comparison detects it, proving the harness can't false-pass.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -107,27 +107,27 @@ All metrics are in the `aerospike_ttl_` namespace.
 ### Example output
 
 ```
-aerospike_ttl_build_info{version="4.1.3"} 1
-aerospike_ttl_default_ttl_seconds{namespace="myNS"} 2851200
-aerospike_ttl_min_ttl_seconds{namespace="myNS",set="Beans"} 1.3824e+07
-aerospike_ttl_max_ttl_seconds{namespace="myNS",set="Beans"} 1.9008e+07
-aerospike_ttl_counts_hist_bucket{namespace="myNS",set="Beans",ttlUnit="days",le="160"} 858
-aerospike_ttl_counts_hist_bucket{namespace="myNS",set="Beans",ttlUnit="days",le="170"} 901
-aerospike_ttl_counts_hist_bucket{namespace="myNS",set="Beans",ttlUnit="days",le="181"} 971
-aerospike_ttl_counts_hist_bucket{namespace="myNS",set="Beans",ttlUnit="days",le="220"} 1004
-aerospike_ttl_counts_hist_bucket{namespace="myNS",set="Beans",ttlUnit="days",le="+Inf"} 1004
-aerospike_ttl_counts_hist_sum{namespace="myNS",set="Beans",ttlUnit="days"} 9.037094916e+09
-aerospike_ttl_counts_hist_count{namespace="myNS",set="Beans",ttlUnit="days"} 1004
-aerospike_ttl_kib_hist_bucket{namespace="myNS",set="Beans",ttlUnit="days",storage_type="recordsize",le="160"} 1938
-aerospike_ttl_kib_hist_bucket{namespace="myNS",set="Beans",ttlUnit="days",storage_type="recordsize",le="220"} 4041
-aerospike_ttl_kib_hist_bucket{namespace="myNS",set="Beans",ttlUnit="days",storage_type="recordsize",le="+Inf"} 4041
-aerospike_ttl_kib_hist_sum{namespace="myNS",set="Beans",ttlUnit="days",storage_type="recordsize"} 5.244241494e+10
-aerospike_ttl_kib_hist_count{namespace="myNS",set="Beans",ttlUnit="days",storage_type="recordsize"} 4041
-aerospike_ttl_size_bytes_hist_bucket{namespace="myNS",set="Beans",metadata_op="recordsize",le="1"} 0
-aerospike_ttl_size_bytes_hist_bucket{namespace="myNS",set="Beans",metadata_op="recordsize",le="5.879"} 12
-aerospike_ttl_size_bytes_hist_bucket{namespace="myNS",set="Beans",metadata_op="recordsize",le="+Inf"} 4041
-aerospike_ttl_scan_last_updated{namespace="myNS",set="Beans"} 1.690408779e+09
-aerospike_ttl_scan_time_seconds{namespace="myNS",set="Beans"} 103
+aerospike_ttl_build_info{version="dev"} 1
+aerospike_ttl_default_ttl_seconds{namespace="test"} 0
+aerospike_ttl_min_ttl_seconds{namespace="test",set="myset"} 86374
+aerospike_ttl_max_ttl_seconds{namespace="test",set="myset"} 86374
+aerospike_ttl_counts_hist_bucket{namespace="test",set="myset",ttlUnit="hours",le="23.76"} 0
+aerospike_ttl_counts_hist_bucket{namespace="test",set="myset",ttlUnit="hours",le="24.384"} 200
+aerospike_ttl_counts_hist_bucket{namespace="test",set="myset",ttlUnit="hours",le="+Inf"} 200
+aerospike_ttl_counts_hist_sum{namespace="test",set="myset",ttlUnit="hours"} 4799.083333333327
+aerospike_ttl_counts_hist_count{namespace="test",set="myset",ttlUnit="hours"} 200
+aerospike_ttl_kib_hist_bucket{namespace="test",set="myset",storage_type="recordsize",ttlUnit="hours",le="23.76"} 0
+aerospike_ttl_kib_hist_bucket{namespace="test",set="myset",storage_type="recordsize",ttlUnit="hours",le="24.384"} 16
+aerospike_ttl_kib_hist_bucket{namespace="test",set="myset",storage_type="recordsize",ttlUnit="hours",le="+Inf"} 16
+aerospike_ttl_kib_hist_sum{namespace="test",set="myset",storage_type="recordsize",ttlUnit="hours"} 382.4269531249998
+aerospike_ttl_kib_hist_count{namespace="test",set="myset",storage_type="recordsize",ttlUnit="hours"} 16
+aerospike_ttl_size_bytes_hist_bucket{metadata_op="recordsize",namespace="test",set="myset",le="34.56227054460177"} 0
+aerospike_ttl_size_bytes_hist_bucket{metadata_op="recordsize",namespace="test",set="myset",le="203.19049958682461"} 200
+aerospike_ttl_size_bytes_hist_bucket{metadata_op="recordsize",namespace="test",set="myset",le="+Inf"} 200
+aerospike_ttl_size_bytes_hist_sum{metadata_op="recordsize",namespace="test",set="myset"} 16320
+aerospike_ttl_size_bytes_hist_count{metadata_op="recordsize",namespace="test",set="myset"} 200
+aerospike_ttl_scan_last_updated{namespace="test",set="myset"} 1.782252482e+09
+aerospike_ttl_scan_time_seconds{namespace="test",set="myset"} 0
 ```
 
 ## Usage

--- a/collector.go
+++ b/collector.go
@@ -131,21 +131,20 @@ type bucketConfig struct {
 }
 
 type monconf struct {
-	Namespace                string       `yaml:"namespace"`
-	Set                      string       `yaml:"set"`
-	Recordcount              int          `yaml:"recordCount,omitempty"`
-	ScanPercent              float64      `yaml:"scanPercent,omitempty"`
-	ReportCount              int          `yaml:"reportCount,omitempty"`
-	ScanTotalTimeout         string       `yaml:"scanTotalTimeout"`
-	ScanSocketTimeout        string       `yaml:"scanSocketTimeout"`
-	PolicyTotalTimeout       string       `yaml:"policyTotalTimeout"`
-	PolicySocketTimeout      string       `yaml:"policySocketTimeout"`
-	RecordsPerSecond         int          `yaml:"recordsPerSecond"`
-	KByteHistogramEnabled    bool         `yaml:"kbyteHistogramEnabled,omitempty"`
-	KByteHistogramResolution float64      `yaml:"kbyteHistogramResolution,omitempty"`
-	SizeHistogramEnabled     bool         `yaml:"sizeHistogramEnabled"`
-	TTLBuckets               bucketConfig `yaml:"ttlBuckets"`
-	SizeBuckets              bucketConfig `yaml:"sizeBuckets"`
+	Namespace             string       `yaml:"namespace"`
+	Set                   string       `yaml:"set"`
+	Recordcount           int          `yaml:"recordCount,omitempty"`
+	ScanPercent           float64      `yaml:"scanPercent,omitempty"`
+	ReportCount           int          `yaml:"reportCount,omitempty"`
+	ScanTotalTimeout      string       `yaml:"scanTotalTimeout"`
+	ScanSocketTimeout     string       `yaml:"scanSocketTimeout"`
+	PolicyTotalTimeout    string       `yaml:"policyTotalTimeout"`
+	PolicySocketTimeout   string       `yaml:"policySocketTimeout"`
+	RecordsPerSecond      int          `yaml:"recordsPerSecond"`
+	KByteHistogramEnabled bool         `yaml:"kbyteHistogramEnabled,omitempty"`
+	SizeHistogramEnabled  bool         `yaml:"sizeHistogramEnabled"`
+	TTLBuckets            bucketConfig `yaml:"ttlBuckets"`
+	SizeBuckets           bucketConfig `yaml:"sizeBuckets"`
 }
 
 // monconfOverride mirrors monconf but with pointer fields for every
@@ -154,21 +153,20 @@ type monconf struct {
 // override a discovered/default set's config field-by-field. Namespace and Set
 // are plain strings because they are the match key, not overridable values.
 type monconfOverride struct {
-	Namespace                string        `yaml:"namespace"`
-	Set                      string        `yaml:"set"`
-	Recordcount              *int          `yaml:"recordCount,omitempty"`
-	ScanPercent              *float64      `yaml:"scanPercent,omitempty"`
-	ReportCount              *int          `yaml:"reportCount,omitempty"`
-	ScanTotalTimeout         *string       `yaml:"scanTotalTimeout,omitempty"`
-	ScanSocketTimeout        *string       `yaml:"scanSocketTimeout,omitempty"`
-	PolicyTotalTimeout       *string       `yaml:"policyTotalTimeout,omitempty"`
-	PolicySocketTimeout      *string       `yaml:"policySocketTimeout,omitempty"`
-	RecordsPerSecond         *int          `yaml:"recordsPerSecond,omitempty"`
-	KByteHistogramEnabled    *bool         `yaml:"kbyteHistogramEnabled,omitempty"`
-	KByteHistogramResolution *float64      `yaml:"kbyteHistogramResolution,omitempty"`
-	SizeHistogramEnabled     *bool         `yaml:"sizeHistogramEnabled,omitempty"`
-	TTLBuckets               *bucketConfig `yaml:"ttlBuckets,omitempty"`
-	SizeBuckets              *bucketConfig `yaml:"sizeBuckets,omitempty"`
+	Namespace             string        `yaml:"namespace"`
+	Set                   string        `yaml:"set"`
+	Recordcount           *int          `yaml:"recordCount,omitempty"`
+	ScanPercent           *float64      `yaml:"scanPercent,omitempty"`
+	ReportCount           *int          `yaml:"reportCount,omitempty"`
+	ScanTotalTimeout      *string       `yaml:"scanTotalTimeout,omitempty"`
+	ScanSocketTimeout     *string       `yaml:"scanSocketTimeout,omitempty"`
+	PolicyTotalTimeout    *string       `yaml:"policyTotalTimeout,omitempty"`
+	PolicySocketTimeout   *string       `yaml:"policySocketTimeout,omitempty"`
+	RecordsPerSecond      *int          `yaml:"recordsPerSecond,omitempty"`
+	KByteHistogramEnabled *bool         `yaml:"kbyteHistogramEnabled,omitempty"`
+	SizeHistogramEnabled  *bool         `yaml:"sizeHistogramEnabled,omitempty"`
+	TTLBuckets            *bucketConfig `yaml:"ttlBuckets,omitempty"`
+	SizeBuckets           *bucketConfig `yaml:"sizeBuckets,omitempty"`
 }
 
 // resolve produces a concrete monconf by starting from base and overwriting only
@@ -188,7 +186,6 @@ func (o monconfOverride) resolve(base monconf) monconf {
 	setIfPresent(&m.PolicySocketTimeout, o.PolicySocketTimeout)
 	setIfPresent(&m.RecordsPerSecond, o.RecordsPerSecond)
 	setIfPresent(&m.KByteHistogramEnabled, o.KByteHistogramEnabled)
-	setIfPresent(&m.KByteHistogramResolution, o.KByteHistogramResolution)
 	setIfPresent(&m.SizeHistogramEnabled, o.SizeHistogramEnabled)
 	// Bucket configs replace wholesale (no field-by-field merge within a block):
 	// a non-nil override block entirely supplants the default.

--- a/conf.yaml
+++ b/conf.yaml
@@ -59,7 +59,7 @@ service:
 
 monitor:
   - namespace: mynamespace
-    set: User # what setname to scan? use `null` (without ticks) to just report on a namespace level
+    set: myset # what setname to scan? use `null` (without ticks) to just report on a namespace level
     recordCount: 50000 # How many records to stop scanning at? If both recordCount and scanPercent are set, the scan stops at whichever limit is reached first.
     scanPercent: 1.1 # what percentage of data to scan? Set to 0 or -1 to disable. Works alongside recordCount.
     reportCount: 300000 # How many records should be report on? Every <x> records will cause an entry in the stdout (default 300000)
@@ -67,7 +67,7 @@ monitor:
     scanSocketTimeout: 20m # https://golang.org/pkg/time/#ParseDuration
     policyTotalTimeout: 20m # https://golang.org/pkg/time/#ParseDuration
     policySocketTimeout: 20m # https://golang.org/pkg/time/#ParseDuration
-    RecordsPerSecond: 0 # Limit the records per second returned by Aerospike server to the exporter. 0 means no limit.
+    recordsPerSecond: 0 # Limit the records per second returned by Aerospike server to the exporter. 0 means no limit.
     # ttlBuckets: TTL histogram boundaries. mode = static|linear|exponential|auto
     # (auto only valid under discoveryDefaults). static values may carry an "s",
     # "h", or "d" suffix; do not mix suffixes within one list.
@@ -95,16 +95,9 @@ monitor:
     scanSocketTimeout: 20m # https://golang.org/pkg/time/#ParseDuration
     policyTotalTimeout: 20m # https://golang.org/pkg/time/#ParseDuration
     policySocketTimeout: 20m # https://golang.org/pkg/time/#ParseDuration
-    RecordsPerSecond: 100 # Utilizes the scan policy to limit RPS.
+    recordsPerSecond: 100 # Utilizes the scan policy to limit RPS.
     ## KiB exports
-    # WARNING: Resolution will have drastic perf implications
-    #  This directly affects how many times we call histogram.Observe.
-    #  If you have a ~128,000 byte size record and resolution is set to 0.001 we will call observe 128,000 times.
-    # this does mean we lose some resolution on how large the records are, because they'll be rounded down by 'n' bytes.
-    # value is in KiB, recommend starting at something like 0.334 so our resolution will be around 334 bytes and we will call observe 334x less.
-    # This also artificially deflates the number, so you will have to scale it up. If we are observing 334x less data, you will need to 334x the final value from the histograms - though they should be accurate as a distribution.
-    #  There is no good way around this.
-    kbyteHistogramResolution: 0.334 # maximum rez 0.001 (1 byte res) which seems to generate more than 30x more compute needs than 0.333
+    # Bucket counts represent total bytes per TTL bucket (O(1) per record).
     kbyteHistogramEnabled: true
     ## Bucket Size exports
     sizeHistogramEnabled: true

--- a/config_test.go
+++ b/config_test.go
@@ -41,7 +41,6 @@ monitor:
       start: 180d
       width: 10d
       count: 10
-    kbyteHistogramResolution: 0.334
     sizeHistogramEnabled: true
     sizeBuckets:
       mode: exponential

--- a/kib_collector.go
+++ b/kib_collector.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"math"
+	"sort"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// kibCollector is a custom prometheus.Collector that accumulates a
+// size-weighted TTL histogram in O(1) per record. Bucket counts represent
+// total KiB of records falling into each TTL bucket, eliminating the
+// former O(size/resolution) Observe() loop and the resolution config knob.
+//
+// Weights are accumulated as fractional KiB (float64) so sub-KiB records sum
+// without loss; the prometheus exposition format requires uint64 bucket
+// counts, so values are rounded once at Collect time (max <1 KiB error per
+// bucket, negligible at real scale).
+type kibCollector struct {
+	mu      sync.Mutex
+	desc    *prometheus.Desc
+	bounds  []float64 // sorted bucket upper bounds (mirrors the TTL histogram)
+	weights []float64 // non-cumulative KiB per bucket (index matches bounds)
+	count   float64   // total KiB across all buckets (incl. +Inf overflow)
+	sum     float64   // KiB-weighted TTL sum: Σ(KiB × expireTime)
+}
+
+func newKibCollector(namespace, set, ttlUnit string, buckets []float64) *kibCollector {
+	sorted := make([]float64, len(buckets))
+	copy(sorted, buckets)
+	sort.Float64s(sorted)
+
+	desc := prometheus.NewDesc(
+		"aerospike_ttl_kib_hist",
+		"Size-weighted TTL histogram: bucket counts represent total KiB of records in each TTL bucket.",
+		[]string{"storage_type"},
+		prometheus.Labels{"namespace": namespace, "set": set, "ttlUnit": ttlUnit},
+	)
+
+	return &kibCollector{
+		desc:    desc,
+		bounds:  sorted,
+		weights: make([]float64, len(sorted)),
+	}
+}
+
+func (c *kibCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *kibCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.Lock()
+	cumBuckets := make(map[float64]uint64, len(c.bounds))
+	var cum float64
+	for i, bound := range c.bounds {
+		cum += c.weights[i]
+		cumBuckets[bound] = uint64(math.Round(cum))
+	}
+	count := uint64(math.Round(c.count))
+	sum := c.sum
+	c.mu.Unlock()
+
+	ch <- prometheus.MustNewConstHistogram(c.desc, count, sum, cumBuckets, "recordsize")
+}
+
+// addWeight records one record's size (converted to KiB) into the TTL bucket
+// matching expireTime. O(1) per record (binary search over bucket bounds).
+func (c *kibCollector) addWeight(expireTime float64, sizeBytes int) {
+	if sizeBytes <= 0 {
+		return
+	}
+	w := float64(sizeBytes) / 1024.0
+	idx := sort.SearchFloat64s(c.bounds, expireTime)
+
+	c.mu.Lock()
+	if idx < len(c.bounds) {
+		c.weights[idx] += w
+	}
+	c.count += w
+	c.sum += w * expireTime
+	c.mu.Unlock()
+}

--- a/kib_collector_test.go
+++ b/kib_collector_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestKibCollectorEmptyCollect(t *testing.T) {
+	c := newKibCollector("ns1", "foo", "days", []float64{10, 20, 30})
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+
+	count := testutil.CollectAndCount(c)
+	if count != 1 {
+		t.Errorf("expected 1 metric (the histogram), got %d", count)
+	}
+}
+
+func TestKibCollectorSingleRecord(t *testing.T) {
+	c := newKibCollector("ns1", "foo", "days", []float64{10, 20, 30})
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+
+	c.addWeight(15.0, 2048) // 2 KiB, TTL=15 days -> bucket le=20
+
+	expected := `
+# HELP aerospike_ttl_kib_hist Size-weighted TTL histogram: bucket counts represent total KiB of records in each TTL bucket.
+# TYPE aerospike_ttl_kib_hist histogram
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="foo",storage_type="recordsize",ttlUnit="days",le="10"} 0
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="foo",storage_type="recordsize",ttlUnit="days",le="20"} 2
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="foo",storage_type="recordsize",ttlUnit="days",le="30"} 2
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="foo",storage_type="recordsize",ttlUnit="days",le="+Inf"} 2
+aerospike_ttl_kib_hist_sum{namespace="ns1",set="foo",storage_type="recordsize",ttlUnit="days"} 30
+aerospike_ttl_kib_hist_count{namespace="ns1",set="foo",storage_type="recordsize",ttlUnit="days"} 2
+`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestKibCollectorMultipleRecordsDifferentBuckets(t *testing.T) {
+	c := newKibCollector("ns1", "bar", "seconds", []float64{100, 200, 300})
+
+	c.addWeight(50.0, 1024)  // 1 KiB -> bucket le=100
+	c.addWeight(150.0, 2048) // 2 KiB -> bucket le=200
+	c.addWeight(250.0, 3072) // 3 KiB -> bucket le=300
+
+	expected := `
+# HELP aerospike_ttl_kib_hist Size-weighted TTL histogram: bucket counts represent total KiB of records in each TTL bucket.
+# TYPE aerospike_ttl_kib_hist histogram
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="bar",storage_type="recordsize",ttlUnit="seconds",le="100"} 1
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="bar",storage_type="recordsize",ttlUnit="seconds",le="200"} 3
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="bar",storage_type="recordsize",ttlUnit="seconds",le="300"} 6
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="bar",storage_type="recordsize",ttlUnit="seconds",le="+Inf"} 6
+aerospike_ttl_kib_hist_sum{namespace="ns1",set="bar",storage_type="recordsize",ttlUnit="seconds"} 1100
+aerospike_ttl_kib_hist_count{namespace="ns1",set="bar",storage_type="recordsize",ttlUnit="seconds"} 6
+`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestKibCollectorOverflowToInf(t *testing.T) {
+	c := newKibCollector("ns1", "baz", "days", []float64{10, 20})
+
+	c.addWeight(25.0, 1024) // 1 KiB, TTL=25 > all bounds -> only in +Inf and count
+
+	expected := `
+# HELP aerospike_ttl_kib_hist Size-weighted TTL histogram: bucket counts represent total KiB of records in each TTL bucket.
+# TYPE aerospike_ttl_kib_hist histogram
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="baz",storage_type="recordsize",ttlUnit="days",le="10"} 0
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="baz",storage_type="recordsize",ttlUnit="days",le="20"} 0
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="baz",storage_type="recordsize",ttlUnit="days",le="+Inf"} 1
+aerospike_ttl_kib_hist_sum{namespace="ns1",set="baz",storage_type="recordsize",ttlUnit="days"} 25
+aerospike_ttl_kib_hist_count{namespace="ns1",set="baz",storage_type="recordsize",ttlUnit="days"} 1
+`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestKibCollectorZeroSizeSkipped(t *testing.T) {
+	c := newKibCollector("ns1", "z", "days", []float64{10})
+	c.addWeight(5.0, 0)
+	c.addWeight(5.0, -1)
+
+	expected := `
+# HELP aerospike_ttl_kib_hist Size-weighted TTL histogram: bucket counts represent total KiB of records in each TTL bucket.
+# TYPE aerospike_ttl_kib_hist histogram
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="z",storage_type="recordsize",ttlUnit="days",le="10"} 0
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="z",storage_type="recordsize",ttlUnit="days",le="+Inf"} 0
+aerospike_ttl_kib_hist_sum{namespace="ns1",set="z",storage_type="recordsize",ttlUnit="days"} 0
+aerospike_ttl_kib_hist_count{namespace="ns1",set="z",storage_type="recordsize",ttlUnit="days"} 0
+`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestKibCollectorBoundaryValue(t *testing.T) {
+	c := newKibCollector("ns1", "edge", "days", []float64{10, 20})
+
+	c.addWeight(10.0, 1024) // 1 KiB, exactly on boundary le=10 -> goes in that bucket
+
+	expected := `
+# HELP aerospike_ttl_kib_hist Size-weighted TTL histogram: bucket counts represent total KiB of records in each TTL bucket.
+# TYPE aerospike_ttl_kib_hist histogram
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="edge",storage_type="recordsize",ttlUnit="days",le="10"} 1
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="edge",storage_type="recordsize",ttlUnit="days",le="20"} 1
+aerospike_ttl_kib_hist_bucket{namespace="ns1",set="edge",storage_type="recordsize",ttlUnit="days",le="+Inf"} 1
+aerospike_ttl_kib_hist_sum{namespace="ns1",set="edge",storage_type="recordsize",ttlUnit="days"} 10
+aerospike_ttl_kib_hist_count{namespace="ns1",set="edge",storage_type="recordsize",ttlUnit="days"} 1
+`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+		t.Error(err)
+	}
+}

--- a/registry.go
+++ b/registry.go
@@ -41,9 +41,9 @@ func nsSetKey(ns, set string) string {
 // Two effectiveSets with equal signatures produce identical collectors, so the
 // registry can skip unregister/re-register churn when the signature is unchanged.
 func (e effectiveSet) signature() string {
-	return fmt.Sprintf("exp=%t|unit=%s|buckets=%v|kb=%t|res=%g|size=%t|sb=%+v",
+	return fmt.Sprintf("exp=%t|unit=%s|buckets=%v|kb=%t|size=%t|sb=%+v",
 		e.expirable, e.ttlUnit, e.buckets,
-		e.cfg.KByteHistogramEnabled, e.cfg.KByteHistogramResolution,
+		e.cfg.KByteHistogramEnabled,
 		e.cfg.SizeHistogramEnabled, e.cfg.SizeBuckets)
 }
 
@@ -54,7 +54,7 @@ type histSet struct {
 	namespace string // retained so prune can delete this set's gauge series
 	set       string
 	counts    *prometheus.HistogramVec
-	bytes     *prometheus.HistogramVec
+	bytes     *kibCollector
 	sizes     *prometheus.HistogramVec
 	modifier  int
 	sig       string
@@ -156,18 +156,6 @@ func newCountsHist(namespace, set, ttlUnit string, buckets []float64) *prometheu
 	}, []string{})
 }
 
-// newBytesHist builds the kib_hist (bytes-per-ttl-bucket) collector. Single
-// shared definition, see newCountsHist.
-func newBytesHist(namespace, set, ttlUnit string, buckets []float64) *prometheus.HistogramVec {
-	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:   "aerospike_ttl",
-		Name:        "kib_hist",
-		Help:        "Histogram of how many bytes fall into each ttl bucket. Memory will be the in-memory data size and does not include PI or SI.",
-		Buckets:     buckets,
-		ConstLabels: prometheus.Labels{"namespace": namespace, "set": set, "ttlUnit": ttlUnit},
-	}, []string{"storage_type"})
-}
-
 // newSizesHist builds the size_bytes_hist (record-size distribution) collector.
 // Single shared definition, see newCountsHist.
 func newSizesHist(namespace, set string, buckets []float64) *prometheus.HistogramVec {
@@ -192,7 +180,7 @@ func buildHistSet(reg prometheus.Registerer, e effectiveSet, sig string) *histSe
 		reg.MustRegister(hs.counts)
 
 		if e.cfg.KByteHistogramEnabled {
-			hs.bytes = newBytesHist(e.namespace, e.set, e.ttlUnit, e.buckets)
+			hs.bytes = newKibCollector(e.namespace, e.set, e.ttlUnit, e.buckets)
 			reg.MustRegister(hs.bytes)
 		}
 	}

--- a/scripts/check.aql
+++ b/scripts/check.aql
@@ -1,3 +1,12 @@
 SET OUTPUT JSON;
 SET RECORD_PRINT_METADATA TRUE;
-SELECT * FROM test.myset WHERE PK = 'canary1';
+SELECT * FROM test.myset WHERE PK = 'canary01';
+SELECT * FROM test.myset WHERE PK = 'canary02';
+SELECT * FROM test.myset WHERE PK = 'canary03';
+SELECT * FROM test.myset WHERE PK = 'canary04';
+SELECT * FROM test.myset WHERE PK = 'canary05';
+SELECT * FROM test.myset WHERE PK = 'canary06';
+SELECT * FROM test.myset WHERE PK = 'canary07';
+SELECT * FROM test.myset WHERE PK = 'canary08';
+SELECT * FROM test.myset WHERE PK = 'canary09';
+SELECT * FROM test.myset WHERE PK = 'canary10';

--- a/scripts/docker-test.yaml
+++ b/scripts/docker-test.yaml
@@ -1,6 +1,6 @@
 ---
 # Exporter config for the ephemeral docker Aerospike used by gen-stability-test.sh.
-# Single community-edition node, no auth, autoDiscover so the seeded `test`
+# Single enterprise-edition node, no auth, autoDiscover so the seeded `test`
 # namespace/set is found and scanned automatically.
 service:
   listenPort: :9634
@@ -23,6 +23,7 @@ service:
     policyTotalTimeout: 20m
     policySocketTimeout: 20m
     sizeHistogramEnabled: true
+    kbyteHistogramEnabled: true
     ttlBuckets:
       mode: auto
     sizeBuckets:

--- a/scripts/gen-stability-test.sh
+++ b/scripts/gen-stability-test.sh
@@ -149,8 +149,14 @@ check_histogram() {
 }
 
 check_histogram "aerospike_ttl_counts_hist" "${CANARY_COUNT}"
-check_histogram "aerospike_ttl_kib_hist" "${CANARY_COUNT}"
+# kib_hist _count is total KiB (size-weighted), NOT record count, so it cannot be
+# compared against CANARY_COUNT. Sub-KiB canaries could sum below the record count
+# yet still be correct. Require only that it produced a positive size-weighted total.
+check_histogram "aerospike_ttl_kib_hist" 1
 check_histogram "aerospike_ttl_size_bytes_hist" "${CANARY_COUNT}"
+
+echo "==> sample /metrics lines (illustrative output):"
+echo "${metrics}" | grep -E "^aerospike_ttl_"
 
 # --- Stop exporter, check gens ---
 kill "${exporter_pid}" 2>/dev/null || true

--- a/scripts/gen-stability-test.sh
+++ b/scripts/gen-stability-test.sh
@@ -8,31 +8,35 @@
 # community-edition node in docker proves it just as well as prod, with no creds
 # or external host.
 #
-# Spins up Aerospike in docker, seeds a canary record, scans it with the
-# exporter for a bounded window, then re-reads gen. Unchanged => read-only
-# (PASS); changed => the exporter wrote (FAIL, loud). Tears the container down.
+# Seeds 10 canary records, scans them with ALL histogram types enabled (counts,
+# kib, size_bytes), then re-reads gen for every record. Any gen change => the
+# exporter wrote (FAIL, loud). After the read-only assertion, verifies:
+#   1. All 10 records' gens are unchanged.
+#   2. Prometheus /metrics shows >= 10 observations for each histogram type,
+#      proving the histograms were actually populated (a test that "passes"
+#      without producing histograms proves nothing).
 #
 # NEGATIVE CONTROL: a test that can only ever PASS is worthless. After the
-# read-only assertion, the harness deliberately writes the canary and confirms
+# read-only assertion, the harness deliberately writes one canary and confirms
 # the SAME gen comparison now reports a change — proving it can actually detect
 # a write. Every gen read is also guarded against an empty result (missing
-# canary / broken check.sh), which would otherwise compare equal and false-PASS.
+# canary / broken aql query), which would otherwise compare equal and false-PASS.
 #
 # Usage: scripts/gen-stability-test.sh        (RUN_SECS=30 to lengthen the scan)
-# Requires: docker, go on PATH. aql runs inside the container (no host aql needed).
+# Requires: docker, go, curl on PATH. aql runs inside the container.
 set -euo pipefail
 
+CANARY_COUNT=10
 RUN_SECS="${RUN_SECS:-20}"
 CONTAINER="ttl-exporter-test-asd"
-IMAGE="aerospike/aerospike-server:latest"
+IMAGE="aerospike/aerospike-server-enterprise:latest"
 LOG="/tmp/gen-test-exporter.log"
 BIN="/tmp/gen-test-exporter.bin"
+METRICS_PORT=9634
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"
-# Route aql through the container's own client: no host aql, and no astools.conf
-# creds to trip community edition's no-auth handshake. localhost = the asd.
 export AEROSPIKE_HOST="127.0.0.1"
 export AQL="docker exec -i ${CONTAINER} aql"
 
@@ -44,16 +48,23 @@ cleanup() {
 }
 trap cleanup EXIT
 
-read_gen() { "${SCRIPT_DIR}/check.sh" | grep -o '"gen": *[0-9]*' | grep -o '[0-9]*$'; }
-
-# require_gen fails loud when a gen read came back empty. A missing or unreadable
-# canary would otherwise make before==after=="" compare equal and FALSE-PASS the
-# whole test. $1 = the read value, $2 = phase label for the message.
-require_gen() {
-  if [[ -z "$1" ]]; then
-    echo "FAIL: could not read canary gen (${2}). Canary missing or check.sh broken; gen-stability result would be meaningless." >&2
-    exit 1
-  fi
+# read_gens outputs one "canaryNN=gen" line per record. The caller captures this
+# into an associative array. Exits non-zero if any canary is missing.
+read_gens() {
+  local phase="$1" missing=0
+  for i in $(seq -w 1 "${CANARY_COUNT}"); do
+    local pk="canary${i}"
+    local gen
+    gen=$(${AQL} -h "${AEROSPIKE_HOST}" -c "SET OUTPUT JSON; SET RECORD_PRINT_METADATA TRUE; SELECT * FROM test.myset WHERE PK = '${pk}'" \
+      | grep -o '"gen": *[0-9]*' | grep -o '[0-9]*$' || true)
+    if [[ -z "${gen}" ]]; then
+      echo "FAIL: could not read gen for ${pk} (${phase}). Canary missing or aql query broken." >&2
+      missing=1
+    else
+      echo "${pk}=${gen}"
+    fi
+  done
+  [[ "${missing}" -eq 0 ]] || return 1
 }
 
 echo "==> starting ${IMAGE} (container ${CONTAINER})..."
@@ -71,53 +82,113 @@ for _ in $(seq 1 90); do
 done
 [[ -n "${ready}" ]] || { echo "FAIL: Aerospike did not become ready in time." >&2; exit 1; }
 
-"${SCRIPT_DIR}/insert.sh" >/dev/null # seed canary
-before="$(read_gen)"
-require_gen "${before}" "before scan"
-echo "==> gen before scan: ${before}"
+# Crank nsup sweep and histogram rebuild to 5s so the TTL histogram is
+# available within seconds of record insertion (defaults are 120s and 3600s).
+docker exec -i "${CONTAINER}" asinfo -v "set-config:context=namespace;id=test;nsup-period=5" >/dev/null
+docker exec -i "${CONTAINER}" asinfo -v "set-config:context=namespace;id=test;nsup-hist-period=5" >/dev/null
 
-# Build + run the binary directly (not `go run .`): killing `go run` orphans the
-# child that holds the listen port, breaking the next run. The binary is the pid
-# we kill.
+echo "==> seeding ${CANARY_COUNT} canary records..."
+"${SCRIPT_DIR}/insert.sh" >/dev/null
+
+# nsup builds the TTL histogram in the background; auto-discovery needs it.
+# Poll until the histogram response contains bucket-width (not "hist-unavailable").
+echo "==> waiting for nsup to build TTL histogram..."
+hist_ready=""
+for _ in $(seq 1 60); do
+  hist_raw=$(docker exec -i "${CONTAINER}" asinfo -v "histogram:namespace=test;set=myset;type=ttl" 2>/dev/null || true)
+  if echo "${hist_raw}" | grep -q "bucket-width"; then
+    hist_ready=1
+    break
+  fi
+  sleep 1
+done
+[[ -n "${hist_ready}" ]] || { echo "FAIL: TTL histogram not available after 60s. nsup may not have run." >&2; exit 1; }
+echo "   histogram ready: $(echo "${hist_raw}" | head -c 80)..."
+
+echo "==> reading gen for all ${CANARY_COUNT} canaries (before scan)..."
+declare -A gens_before
+while IFS='=' read -r pk gen; do
+  gens_before["${pk}"]="${gen}"
+done < <(read_gens "before scan")
+echo "   gens before: ${gens_before[*]}"
+
 echo "==> building exporter..."
 go build -o "${BIN}" .
 "${BIN}" -configFile "${SCRIPT_DIR}/docker-test.yaml" >"${LOG}" 2>&1 &
 exporter_pid=$!
 echo "==> exporter pid ${exporter_pid} scanning for ${RUN_SECS}s (log: ${LOG})..."
 sleep 3
-# Liveness guard: a dead exporter never scans, so an unchanged gen would be a
-# false pass. Fail loud instead.
+
 if ! kill -0 "${exporter_pid}" 2>/dev/null; then
   echo "FAIL: exporter exited before scanning. Last log lines:" >&2
   tail -n 20 "${LOG}" >&2
   exit 1
 fi
+
 sleep "$(( RUN_SECS > 3 ? RUN_SECS - 3 : 1 ))"
+
+# --- Histogram verification (while exporter is still alive) ---
+echo "==> verifying histogram output at :${METRICS_PORT}/metrics..."
+metrics=$(curl -sf "http://localhost:${METRICS_PORT}/metrics") || {
+  echo "FAIL: could not scrape /metrics from exporter." >&2
+  tail -n 20 "${LOG}" >&2
+  exit 1
+}
+
+check_histogram() {
+  local name="$1" min_samples="$2"
+  local count
+  count=$(echo "${metrics}" | grep "^${name}_count" | awk '{s+=$2} END {printf "%.0f", s+0}')
+  if [[ -z "${count}" || "${count}" -lt "${min_samples}" ]]; then
+    echo "FAIL: ${name} has ${count:-0} observations, need >= ${min_samples}. Exporter did not produce this histogram; gen-stability result would be meaningless." >&2
+    echo "--- relevant /metrics lines ---" >&2
+    echo "${metrics}" | grep "^${name}" >&2 || echo "(none)" >&2
+    exit 1
+  fi
+  echo "   ${name}: ${count} observations (>= ${min_samples} required)"
+}
+
+check_histogram "aerospike_ttl_counts_hist" "${CANARY_COUNT}"
+check_histogram "aerospike_ttl_kib_hist" "${CANARY_COUNT}"
+check_histogram "aerospike_ttl_size_bytes_hist" "${CANARY_COUNT}"
+
+# --- Stop exporter, check gens ---
 kill "${exporter_pid}" 2>/dev/null || true
 wait "${exporter_pid}" 2>/dev/null || true
 exporter_pid=""
 
-after="$(read_gen)"
-require_gen "${after}" "after scan"
-echo "==> gen after scan:  ${after}"
+echo "==> reading gen for all ${CANARY_COUNT} canaries (after scan)..."
+declare -A gens_after
+while IFS='=' read -r pk gen; do
+  gens_after["${pk}"]="${gen}"
+done < <(read_gens "after scan")
+echo "   gens after: ${gens_after[*]}"
 
-if [[ "${before}" != "${after}" ]]; then
-  echo "FAIL: gen changed ${before} -> ${after}. Exporter performed a WRITE. VERY DANGEROUS." >&2
+failed=0
+for pk in "${!gens_before[@]}"; do
+  before="${gens_before[${pk}]}"
+  after="${gens_after[${pk}]}"
+  if [[ "${before}" != "${after}" ]]; then
+    echo "FAIL: ${pk} gen changed ${before} -> ${after}. Exporter performed a WRITE. VERY DANGEROUS." >&2
+    failed=1
+  fi
+done
+[[ "${failed}" -eq 0 ]] || exit 1
+echo "==> PASS (read-only): all ${CANARY_COUNT} gens unchanged."
+
+# --- Negative control: prove the harness can detect a write ---
+echo "==> negative control: writing canary01 deliberately to confirm a write is detectable..."
+${AQL} -h "${AEROSPIKE_HOST}" -c "SET RECORD_TTL 86400; INSERT INTO test.myset (PK,mybin) VALUES ('canary01','MODIFIED')" >/dev/null
+control_gen=$(${AQL} -h "${AEROSPIKE_HOST}" -c "SET OUTPUT JSON; SET RECORD_PRINT_METADATA TRUE; SELECT * FROM test.myset WHERE PK = 'canary01'" \
+  | grep -o '"gen": *[0-9]*' | grep -o '[0-9]*$' || true)
+if [[ -z "${control_gen}" ]]; then
+  echo "FAIL: could not read canary01 gen after deliberate write." >&2
   exit 1
 fi
-echo "==> PASS (read-only): gen unchanged (${after})."
-
-# NEGATIVE CONTROL: prove the assertion above can actually fire. Deliberately
-# write the canary (insert bumps gen) with the exporter already dead, then run
-# the SAME read+compare. If gen does NOT move here, the harness cannot detect a
-# write, so the read-only PASS above is meaningless — fail loud.
-echo "==> negative control: writing canary deliberately to confirm a write is detectable..."
-"${SCRIPT_DIR}/insert.sh" >/dev/null
-control="$(read_gen)"
-require_gen "${control}" "after deliberate write"
-echo "==> gen after write: ${control}"
-if [[ "${control}" == "${after}" ]]; then
-  echo "FAIL: deliberate write did not move gen (${after} -> ${control}). The harness CANNOT detect writes; the read-only result is meaningless." >&2
+echo "==> gen after write: ${control_gen}"
+if [[ "${control_gen}" == "${gens_after[canary01]}" ]]; then
+  echo "FAIL: deliberate write did not move gen (${gens_after[canary01]} -> ${control_gen}). The harness CANNOT detect writes; the read-only result is meaningless." >&2
   exit 1
 fi
-echo "PASS: exporter is read-only (gen ${after}) AND the harness proved it can detect a write (gen ${after} -> ${control})."
+
+echo "PASS: exporter is read-only (all ${CANARY_COUNT} gens unchanged) AND produced all histogram types AND the harness proved it can detect a write (canary01 gen ${gens_after[canary01]} -> ${control_gen})."

--- a/scripts/insert.aql
+++ b/scripts/insert.aql
@@ -1,13 +1,24 @@
-# Seed the gen-stability canary. Writing the record bumps its gen; the test
-# asserts gen is UNCHANGED after the exporter scans it (proving read-only).
+# Seed gen-stability canary records. Writing bumps gen; the test asserts gen is
+# UNCHANGED after the exporter scans them (proving read-only).
 #
-# SET RECORD_TTL gives the canary a positive TTL (86400s = 1 day) so it is
+# SET RECORD_TTL gives each canary a positive TTL (86400s = 1 day) so they are
 # EXPIRABLE. This matters: stats.go's processRecord returns early for
-# non-expirable records BEFORE the size path, so a TTL-less canary never
-# exercised the metadata-only client.Operate read (measureRecordSize). With a
-# positive TTL and docker-test.yaml's sizeHistogramEnabled:true, the scan now
-# runs that Operate path, and the unchanged-gen assertion proves it is read-only
-# too. The TTL (1 day) is far larger than the scan window (RUN_SECS default 20s),
-# so the canary cannot expire/evict mid-test.
+# non-expirable records BEFORE the kbyte path, so TTL-less canaries never
+# exercise the metadata-only client.Operate read (measureRecordSize). With a
+# positive TTL and docker-test.yaml's sizeHistogramEnabled + kbyteHistogramEnabled,
+# the scan runs that Operate path for every record, and the unchanged-gen
+# assertion proves it is read-only too. The TTL (1 day) is far larger than the
+# scan window (RUN_SECS default 20s), so canaries cannot expire/evict mid-test.
+#
+# 10 records with varying bin sizes give histograms non-trivial data to bucket.
 SET RECORD_TTL 86400
-INSERT INTO test.myset (PK,mybin) VALUES ('canary1',2)
+INSERT INTO test.myset (PK,mybin) VALUES ('canary01','a')
+INSERT INTO test.myset (PK,mybin) VALUES ('canary02','ab')
+INSERT INTO test.myset (PK,mybin) VALUES ('canary03','abc')
+INSERT INTO test.myset (PK,mybin) VALUES ('canary04','abcd')
+INSERT INTO test.myset (PK,mybin) VALUES ('canary05','abcde')
+INSERT INTO test.myset (PK,mybin) VALUES ('canary06','abcdef')
+INSERT INTO test.myset (PK,mybin) VALUES ('canary07','abcdefg')
+INSERT INTO test.myset (PK,mybin) VALUES ('canary08','abcdefgh')
+INSERT INTO test.myset (PK,mybin) VALUES ('canary09','abcdefghi')
+INSERT INTO test.myset (PK,mybin) VALUES ('canary10','abcdefghij')

--- a/stats.go
+++ b/stats.go
@@ -450,12 +450,8 @@ func observeRecordSize(rec *as.Result, element monconf, hs *histSet, expireTime 
 	if err != nil && err != as.ErrKeyNotFound { // key-not-found is debug-logged earlier and non-fatal.
 		logrus.Errorf("Failure fetching record size. Err: %v", err)
 	}
-	// KByteHistogramResolution is the loop step; a zero step would spin forever.
-	if element.KByteHistogramEnabled && hs.bytes != nil && element.KByteHistogramResolution > 0 {
-		bytesTTLSize := float64(recordsize) / 1024.0
-		for i := 0.0; i < bytesTTLSize; i += element.KByteHistogramResolution {
-			hs.bytes.WithLabelValues("recordsize").Observe(expireTime)
-		}
+	if element.KByteHistogramEnabled && hs.bytes != nil {
+		hs.bytes.addWeight(expireTime, recordsize)
 	}
 	if element.SizeHistogramEnabled && hs.sizes != nil && recordsize != 0 {
 		hs.sizes.WithLabelValues("recordsize").Observe(float64(recordsize))


### PR DESCRIPTION
  ## Summary
  - Replace O(size/resolution) Observe loop with `kibCollector`: custom prometheus.Collector
    that accumulates KiB weights per TTL bucket in O(1) via binary search. Eliminates
    `kbyteHistogramResolution` config knob entirely.
  - Stronger gen-stability test: 10 canary records (was 1), enterprise image, histogram
    observation count assertions, nsup period tuning.
  - Minor: sed delimiter fix in Justfile, RecordsPerSecond YAML casing, doc typo.
